### PR TITLE
add 'root' to docs example

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,20 +6,21 @@ Plack::Middleware::DirIndex - Middleware to use with Plack::App::Directory and t
 
     use Plack::Builder;
     use Plack::App::File;
-    use Plack::Middleware::DirIndex;
 
     my $app = Plack::App::File->new({ root => './htdocs/' })->to_app;
 
     builder {
-          enable "Plack::Middleware::DirIndex", dir_index => 'index.html';
+          enable "Plack::Middleware::DirIndex", 
+                dir_index => 'home.htm', 
+                root => './htdocs/';
           $app;
     }
     
 
 # DESCRIPTION
 
-If $env->{PATH\_INFO} ends with a '/' then we will append the dir\_index
-value to it (defaults to index.html)
+If `$env->{PATH_INFO}` ends with a '`/`' then we will append the `dir_index`
+value to it (**defaults to `index.html`**)
 
 # COPYRIGHT & LICENSE
 

--- a/lib/Plack/Middleware/DirIndex.pm
+++ b/lib/Plack/Middleware/DirIndex.pm
@@ -16,12 +16,13 @@ Plack::Middleware::DirIndex - Middleware to use with Plack::App::Directory and t
 
   use Plack::Builder;
   use Plack::App::File;
-  use Plack::Middleware::DirIndex;
 
   my $app = Plack::App::File->new({ root => './htdocs/' })->to_app;
 
   builder {
-        enable "Plack::Middleware::DirIndex", dir_index => 'index.html';
+        enable "Plack::Middleware::DirIndex",
+            dir_index => 'home.htm',
+            root => './htdocs/';
         $app;
   }
   


### PR DESCRIPTION
* without specifying "root" param to DirIndex (while specifying it to Plack::App::File) we get error 404 trying to open a home page without specifying html file. I think because it's trying to open the default "."
ex: `http://localhost:5000/` gives error 404, while `http://localhost:5000/index.html` renders the page.
* specifying `use Plack::Middleware::DirIndex;` seems to be not required for it to work
* in the example i changed dir_index to `dir_index => 'home.htm',` , because, I think showing it with the default value doesn't demonstrate what it can do. if the index file is `index.html` it can be omitted all together.

feel free to reject, as these are just my observations working with the example from these docs, and trying to figure out why `http://localhost:5000/` gives me 404 :-)

thanks!